### PR TITLE
Reorganization of exo_operate Function

### DIFF
--- a/picocoap/src/coap.c
+++ b/picocoap/src/coap.c
@@ -132,8 +132,15 @@ coap_option coap_get_option_by_num(coap_pdu *pdu, coap_option_number num, uint8_
 
 		if (option.num == num) {
 			i++;
+		} else if (option.num > num) {
+			option.num = 0;
+			option.len = 0;
+			option.val = NULL;
+			break;
+		} else if (option.num == 0) {
+			break;
 		}
-	} while (i < occ);
+	} while (i <= occ);
 
 	return option;
 }

--- a/picocoap/src/coap.c
+++ b/picocoap/src/coap.c
@@ -247,13 +247,15 @@ coap_error coap_init_pdu(coap_pdu *pdu)
 	if (pdu->max < 4)
 		return CE_INSUFFICIENT_BUFFER;
 
+	pdu->len = 0;
+	memset(pdu->buf, 0, 4);
+
 	coap_set_version(pdu, COAP_V1);
 	coap_set_type(pdu, CT_RST);
 	coap_set_token(pdu, 0, 0);
 	coap_set_code(pdu, CC_EMPTY);
 	coap_set_mid(pdu, 0);
 
-	pdu->len = 4;
 	pdu->opt_ptr = NULL;
 
 	return CE_NONE;

--- a/picocoap/tests/coap_test.c
+++ b/picocoap/tests/coap_test.c
@@ -161,6 +161,22 @@ static char * test_msg_get_con_getters() {
 	mu_assert("[ERROR] GET CON option two value was wrong.",
 	          memcmp(option.val, ref_bin+14, option.len) == 0);
 
+	option = coap_get_option_by_num(&msg_ref, CON_URI_QUERY, 0);
+	mu_assert("[ERROR] GET CON option by num length was wrong.",
+	          option.len == 40);
+	mu_assert("[ERROR] GET CON option by num number was wrong.",
+	          option.num == CON_URI_QUERY);
+	mu_assert("[ERROR] GET CON option by num value was wrong.",
+	          memcmp(option.val, ref_bin+14, option.len) == 0);
+
+	option = coap_get_option_by_num(&msg_ref, CON_ETAG, 0);
+	mu_assert("[ERROR] GET CON non-option by num length not zero.",
+	          option.len == 0);
+	mu_assert("[ERROR] GET CON non-option by num number not null.",
+	          option.num == 0);
+	mu_assert("[ERROR] GET CON non-option by num value not null.",
+	          option.val == NULL);
+
 	return 0;
 }
 

--- a/src/exosite.c
+++ b/src/exosite.c
@@ -197,6 +197,8 @@ void exo_op_init(exo_op *op)
   op->value_max = 0;
   op->mid = 0;
   op->obs_seq = 0;
+  op->tkl = 0;
+  op->token = 0;
   op->timeout = 0;
 }
 

--- a/src/exosite.c
+++ b/src/exosite.c
@@ -386,6 +386,11 @@ static void exo_process_waiting_datagrams(exo_op *op, uint8_t count)
                     max_age = opt.val[0];
                   }
 
+                  opt = coap_get_option_by_num(&pdu, CON_OBSERVE, 0);
+                  for (int j = 0; j < opt.len; j++) {
+                    op[i].obs_seq = (op[i].obs_seq << (8*j)) | opt.val[j];
+                  }
+
                   // Set timeout between Max-Age to Max-Age + ACK_RANDOM_FACTOR (CoAP Defined)
                   op[i].timeout = exopal_get_time() + (max_age * 1000000)
                                                     + (((uint64_t)rand() % 1500000));

--- a/src/exosite.c
+++ b/src/exosite.c
@@ -292,7 +292,6 @@ static void exo_process_waiting_datagrams(exo_op *op, uint8_t count)
   coap_pdu pdu;
   coap_payload payload;
   int i;
-  uint64_t now = exopal_get_time();
 
   pdu.buf = buf;
   pdu.max = 576;

--- a/src/exosite.c
+++ b/src/exosite.c
@@ -62,6 +62,9 @@ static const char *serial;
 static uint16_t message_id_counter;
 static exo_device_state device_state = EXO_STATE_UNINITIALIZED;
 
+// Internal Constants
+static const int MINIMUM_DATAGRAM_SIZE = 576; // RFC791: all hosts must accept minimum of 576 octets
+
 /*!
  * \brief  Initializes the Exosite library
  *
@@ -290,13 +293,13 @@ exo_state exo_operate(exo_op *op, uint8_t count)
 
 static void exo_process_waiting_datagrams(exo_op *op, uint8_t count)
 {
-  uint8_t buf[576];
+  uint8_t buf[MINIMUM_DATAGRAM_SIZE];
   coap_pdu pdu;
   coap_payload payload;
   int i;
 
   pdu.buf = buf;
-  pdu.max = 576;
+  pdu.max = MINIMUM_DATAGRAM_SIZE;
   pdu.len = 0;
 
   // receive a UDP packet if one or more waiting
@@ -431,13 +434,13 @@ static void exo_process_waiting_datagrams(exo_op *op, uint8_t count)
 // process all ops that are in an active state
 static void exo_process_active_ops(exo_op *op, uint8_t count)
 {
-  uint8_t buf[576];
+  uint8_t buf[MINIMUM_DATAGRAM_SIZE];
   coap_pdu pdu;
   int i;
   uint64_t now = exopal_get_time();
 
   pdu.buf = buf;
-  pdu.max = 576;
+  pdu.max = MINIMUM_DATAGRAM_SIZE;
   pdu.len = 0;
 
   for (i = 0; i < count; i++) {

--- a/src/exosite.c
+++ b/src/exosite.c
@@ -306,10 +306,14 @@ static void exo_process_waiting_datagrams(exo_op *op, uint8_t count)
     for (i = 0; i < count; i++) {
       if(op[i].type == EXO_WRITE) {
         if (op[i].state == EXO_REQUEST_PENDING && op[i].mid == coap_get_mid(&pdu)) {
-          if (coap_get_code_class(&pdu) == 2)
+          if (coap_get_code_class(&pdu) == 2) {
             op[i].state = EXO_REQUEST_SUCCESS;
-          else
+          } else {
             op[i].state = EXO_REQUEST_ERROR;
+
+            if (coap_get_code(&pdu) == CC_UNAUTHORIZED)
+              device_state = EXO_STATE_BAD_CIK;
+          }
           break;
         }
       } else if(op[i].type == EXO_READ) {

--- a/src/exosite.c
+++ b/src/exosite.c
@@ -320,7 +320,7 @@ static void exo_process_waiting_datagrams(exo_op *op, uint8_t count)
           if (coap_get_code_class(&pdu) == 2) {
             payload = coap_get_payload(&pdu);
             if (payload.len == 0) {
-              op[i].value = 0;
+              op[i].value[0] = '\0';
             } else if (payload.len+1 > op[i].value_max || op[i].value == 0) {
               op[i].state = EXO_REQUEST_ERROR;
             } else{
@@ -341,7 +341,7 @@ static void exo_process_waiting_datagrams(exo_op *op, uint8_t count)
           if (coap_get_code_class(&pdu) == 2) {
             payload = coap_get_payload(&pdu);
             if (payload.len == 0) {
-              op[i].value = 0;
+              op[i].value[0] = '\0';
             } else if (payload.len+1 > op[i].value_max || op[i].value == 0) {
               op[i].state = EXO_REQUEST_ERROR;
             } else{
@@ -367,7 +367,7 @@ static void exo_process_waiting_datagrams(exo_op *op, uint8_t count)
 
           payload = coap_get_payload(&pdu);
           if (payload.len == 0) {
-            op[i].value = 0;
+            op[i].value[0] = '\0';
           } else if (payload.len+1 > op[i].value_max || op[i].value == 0) {
             op[i].state = EXO_REQUEST_ERROR;
           } else{

--- a/src/exosite.c
+++ b/src/exosite.c
@@ -262,7 +262,7 @@ exo_state exo_operate(exo_op *op, uint8_t count)
       return EXO_ERROR;
     case EXO_STATE_INITIALIZED:
     case EXO_STATE_BAD_CIK:
-      if (op[0].state == EXO_REQUEST_NULL && op[0].timeout == 0)
+      if (op[0].state == EXO_REQUEST_NULL || op[0].timeout < exopal_get_time())
         exo_activate(&op[0]);
     case EXO_STATE_GOOD:
       break;
@@ -385,7 +385,10 @@ static void exo_process_waiting_datagrams(exo_op *op, uint8_t count)
             op[i].state = EXO_REQUEST_ERROR;
 
             if (coap_get_code(&pdu) == CC_UNAUTHORIZED){
-              device_state = EXO_STATE_BAD_CIK;
+              //device_state = EXO_STATE_BAD_CIK;
+
+              if (op[0].type == EXO_NULL || op[0].timeout < exopal_get_time())
+                exo_activate(&op[0]);
             } else if (coap_get_code(&pdu) == CC_NOT_FOUND) {
               device_state = EXO_STATE_GOOD;
             }


### PR DESCRIPTION
This is a pretty substantial reorganization of the exo_operate function. The goal is to make it much more obvious what is going on where. This is acomplished by first splitting some of the tasks out into named functions (that the compiler will probably inline anyway) as well as changing the order of the checks to reduce code duplication. There are very likely more simplifications that can be made, but I think this is a good start.

This is also a test to see if we like doing code review using GH's PRs, extensive review of the code is not expected.